### PR TITLE
updated transform to use emails for user and group keys 

### DIFF
--- a/go.work
+++ b/go.work
@@ -7,6 +7,7 @@ use (
 	./plugins/azuread
 	./plugins/cognito
 	./plugins/google
+	./plugins/hubspot
 	./plugins/okta
 	./sdk
 )

--- a/go.work
+++ b/go.work
@@ -7,7 +7,6 @@ use (
 	./plugins/azuread
 	./plugins/cognito
 	./plugins/google
-	./plugins/hubspot
 	./plugins/okta
 	./sdk
 )

--- a/plugins/google/pkg/app/assets/transform_template.tmpl
+++ b/plugins/google/pkg/app/assets/transform_template.tmpl
@@ -3,11 +3,12 @@
   "objects": [
   {{ if contains $.kind "admin#directory#user" }}
     {
-      "key": "{{ $.id }}",
+      "key": "{{ $email }}",
       "type": "user",
       "displayName": "{{ $.name.fullName }}",
       "created_at":"{{ $.creationTime }}",
       "properties":{
+        "id": "{{ $.id }}",
         "email": "{{ $email }}",
         {{ if $.recoveryPhone }}
         "phone": "{{ $.recoveryPhone }}",
@@ -34,9 +35,13 @@
 
   {{ if contains $.kind "admin#directory#group" }}
     {
-      "key": "{{ $.id }}",
+      "key": "{{ $.email }}",
       "type": "group",
-      "displayName": "{{ $.name }}"
+      "displayName": "{{ $.name }}",
+      "properties": {
+        "email": "{{ $.email }}",
+        "id": "{{ $.id }}"
+      }
     }
   {{ end }}
   ],
@@ -46,7 +51,7 @@
       "relation": "identifier",
       "subject": {
         "type": "user",
-        "key": "{{$.id}}"
+        "key": "{{$email}}"
       },
       "object": {
         "type": "identity",
@@ -57,7 +62,7 @@
       "relation": "identifier",
       "subject": {
         "type": "user",
-        "key": "{{$.id}}"
+        "key": "{{$email}}"
       },
       "object": {
         "type": "identity",
@@ -82,11 +87,11 @@
         "relation": "member",
         "subject": {
             "type": "{{$subject_type}}",
-            "key": "{{$element.id}}"
+            "key": "{{$element.email}}"
         },
         "object": {
             "type": "group",
-            "key": "{{$.id}}"
+            "key": "{{$.email}}"
         }
       }
       {{ end }}


### PR DESCRIPTION
The previous transform used the google-assigned IDs. This PR moves these IDs to be properties of the user / group.

The identity relations are still created based on both email and ID.  So a user can be looked up via their identity (email or PID).

This change allows enhancing these users with relationships that are derived from other systems (e.g. Workday) by joining on the email as the expected key for the user.