### PR TITLE
updated templates for LDAP and Azure AD to support nested groups

### DIFF
--- a/plugins/azuread/pkg/app/assets/transform_template.tmpl
+++ b/plugins/azuread/pkg/app/assets/transform_template.tmpl
@@ -18,6 +18,7 @@
         "relation": "member",
         "subject_type": "group",
         "subject_id": "{{$.id}}",
+        "subject_relation": "member",
         "object_type": "group",
         "object_id": "{{$element.id}}"
       }

--- a/plugins/ldap/pkg/app/assets/transform_template.tmpl
+++ b/plugins/ldap/pkg/app/assets/transform_template.tmpl
@@ -105,7 +105,8 @@
             "object_id": "{{ $.Key }}",
             "relation": "member",
             "subject_type": "group",
-            "subject_id": "{{ $member }}"
+            "subject_id": "{{ $member }}",
+            "subject_relation": "member"
           }
         {{ end }}
       {{end}}


### PR DESCRIPTION
The LDAP and Azure AD plugins both support nested groups. This PR adds the "member" subject_relation to group-to-group relations.

Auth0, Okta, and Cognito providers appear to all be written to return just users and their group memberships. If these providers do support the notion of nested groups, we aren't importing them today, and the providers would have to be rewritten to support this.
