### PR TITLE
small fix for run command

### DIFF
--- a/plugins/fusionauth/pkg/app/exec.go
+++ b/plugins/fusionauth/pkg/app/exec.go
@@ -24,7 +24,7 @@ func (cmd *ExecCmd) Run(ctx *cc.CommonCtx) error {
 	if err != nil {
 		return err
 	}
-	fetcher = fetcher.WithGroups(cmd.Groups)
+	fetcher = fetcher.WithGroups(cmd.Groups).WithHost(cmd.HostURL)
 
 	templateContent, err := cmd.getTemplateContent()
 	if err != nil {


### PR DESCRIPTION
Currently the fetch command is passed the HostURL which it can use to construct absolute URLs (e.g. imageURL) that come out of the FusionAuth fetcher.

This PR adds the .WithHost() to the `exec` command as well.
