### PR TITLE
add --service-name CLI parameter to openapi plugin

### DIFF
--- a/plugins/openapi/pkg/app/exec.go
+++ b/plugins/openapi/pkg/app/exec.go
@@ -14,7 +14,7 @@ type ExecCmd struct {
 }
 
 func (cmd *ExecCmd) Run(ctx *cc.CommonCtx) error {
-	openapiClient, err := openapi.New(cmd.Directory, cmd.URL, cmd.IDFormat)
+	openapiClient, err := openapi.New(cmd.Directory, cmd.URL, cmd.IDFormat, cmd.ServiceName)
 	if err != nil {
 		return err
 	}
@@ -23,7 +23,7 @@ func (cmd *ExecCmd) Run(ctx *cc.CommonCtx) error {
 	if err != nil {
 		return err
 	}
-	fetcher = fetcher.WithDirectory(cmd.Directory).WithURL(cmd.URL).WithIDFormat(cmd.IDFormat)
+	fetcher = fetcher.WithDirectory(cmd.Directory).WithURL(cmd.URL).WithIDFormat(cmd.IDFormat).WithServiceName(cmd.ServiceName)
 
 	templateContent, err := cmd.getTemplateContent()
 	if err != nil {

--- a/plugins/openapi/pkg/app/fetch.go
+++ b/plugins/openapi/pkg/app/fetch.go
@@ -9,13 +9,14 @@ import (
 )
 
 type FetchCmd struct {
-	Directory string `short:"d" help:"OpenAPI Spec Directory" env:"OPENAPI_DIRECTORY"`
-	URL       string `short:"u" help:"OpenAPI Spec URL" env:"OPENAPI_URL"`
-	IDFormat  string `short:"f" help:"ID Format (base64, canonical, default)" env:"OPENAPI_IDFORMAT"`
+	Directory   string `short:"d" help:"OpenAPI Spec Directory" env:"OPENAPI_DIRECTORY"`
+	URL         string `short:"u" help:"OpenAPI Spec URL" env:"OPENAPI_URL"`
+	IDFormat    string `short:"f" help:"ID Format (base64, canonical, default)" env:"OPENAPI_IDFORMAT"`
+	ServiceName string `short:"n" help:"Service name when importing from a URL" env:"OPENAPI_SERVICE_NAME"`
 }
 
 func (cmd *FetchCmd) Run(ctx *cc.CommonCtx) error {
-	openapiClient, err := openapi.New(cmd.Directory, cmd.URL, cmd.IDFormat)
+	openapiClient, err := openapi.New(cmd.Directory, cmd.URL, cmd.IDFormat, cmd.ServiceName)
 	if err != nil {
 		return err
 	}
@@ -24,7 +25,7 @@ func (cmd *FetchCmd) Run(ctx *cc.CommonCtx) error {
 	if err != nil {
 		return err
 	}
-	fetcher = fetcher.WithDirectory(cmd.Directory).WithURL(cmd.URL).WithIDFormat(cmd.IDFormat)
+	fetcher = fetcher.WithDirectory(cmd.Directory).WithURL(cmd.URL).WithIDFormat(cmd.IDFormat).WithServiceName(cmd.ServiceName)
 
 	return fetcher.Fetch(ctx.Context, os.Stdout, os.Stderr)
 }

--- a/plugins/openapi/pkg/app/verify.go
+++ b/plugins/openapi/pkg/app/verify.go
@@ -11,7 +11,7 @@ type VerifyCmd struct {
 }
 
 func (v *VerifyCmd) Run(ctx *cc.CommonCtx) error {
-	openapiClient, err := openapi.New(v.Directory, v.URL, v.IDFormat)
+	openapiClient, err := openapi.New(v.Directory, v.URL, v.IDFormat, v.ServiceName)
 	if err != nil {
 		return err
 	}

--- a/plugins/openapi/pkg/fetch/fetch.go
+++ b/plugins/openapi/pkg/fetch/fetch.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Fetcher struct {
-	client    *openapi.Client
-	directory string
-	specURL   string
-	idFormat  string
+	client      *openapi.Client
+	directory   string
+	idFormat    string
+	specURL     string
+	serviceName string
 }
 
 func New(client *openapi.Client) (*Fetcher, error) {
@@ -33,6 +34,11 @@ func (f *Fetcher) WithURL(url string) *Fetcher {
 
 func (f *Fetcher) WithIDFormat(idFormat string) *Fetcher {
 	f.idFormat = idFormat
+	return f
+}
+
+func (f *Fetcher) WithServiceName(serviceName string) *Fetcher {
+	f.serviceName = serviceName
 	return f
 }
 

--- a/plugins/openapi/pkg/openapi/openapi.go
+++ b/plugins/openapi/pkg/openapi/openapi.go
@@ -37,7 +37,7 @@ type Service struct {
 	ID          string `json:"id"`
 }
 
-func New(directory, specURL, idFormat string) (*Client, error) {
+func New(directory, specURL, idFormat, serviceName string) (*Client, error) {
 	c := &Client{}
 	c.idFormat = idFormat
 	c.docs = make([]*openapi3.T, 0)
@@ -50,6 +50,12 @@ func New(directory, specURL, idFormat string) (*Client, error) {
 		doc, err := openapi3.NewLoader().LoadFromURI(parsedURL)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot load OpenAPI spec from URL : %s", specURL)
+		}
+		if serviceName != "" {
+			if doc.Info.Extensions == nil {
+				doc.Info.Extensions = make(map[string]interface{}, 0)
+			}
+			doc.Info.Extensions["ServiceName"] = serviceName
 		}
 		c.docs = append(c.docs, doc)
 	}
@@ -80,7 +86,11 @@ func New(directory, specURL, idFormat string) (*Client, error) {
 func (c *Client) ListServices() ([]Service, error) {
 	services := make([]Service, 0)
 	for _, service := range c.docs {
-		svc := newService(service.Info.Title, c.idFormat)
+		id := ""
+		if service.Info.Extensions["ServiceName"] != "" {
+			id = service.Info.Extensions["ServiceName"].(string)
+		}
+		svc := newService(service.Info.Title, id, c.idFormat)
 		services = append(services, *svc)
 	}
 	return services, nil
@@ -97,30 +107,34 @@ func (c *Client) ListAPIs() ([]API, error) {
 
 func (c *Client) ListAPIsInService(service *openapi3.T, idFormat string) []API {
 	apis := make([]API, 0)
+	serviceID := service.Info.Extensions["ServiceName"].(string)
+	if serviceID == "" {
+		serviceID = service.Info.Title
+	}
 	for pathKey, pathItem := range service.Paths.Map() {
 
 		if pathItem.Get != nil {
-			api := newAPI(service.Info.Title, "GET", pathKey, idFormat)
+			api := newAPI(serviceID, "GET", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Post != nil {
-			api := newAPI(service.Info.Title, "POST", pathKey, idFormat)
+			api := newAPI(serviceID, "POST", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Put != nil {
-			api := newAPI(service.Info.Title, "PUT", pathKey, idFormat)
+			api := newAPI(serviceID, "PUT", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Patch != nil {
-			api := newAPI(service.Info.Title, "PATCH", pathKey, idFormat)
+			api := newAPI(serviceID, "PATCH", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Delete != nil {
-			api := newAPI(service.Info.Title, "DELETE", pathKey, idFormat)
+			api := newAPI(serviceID, "DELETE", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Options != nil {
-			api := newAPI(service.Info.Title, "OPTIONS", pathKey, idFormat)
+			api := newAPI(serviceID, "OPTIONS", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 	}
@@ -128,11 +142,15 @@ func (c *Client) ListAPIsInService(service *openapi3.T, idFormat string) []API {
 	return apis
 }
 
-func newService(name, idFormat string) *Service {
+func newService(name, id, idFormat string) *Service {
 	service := &Service{}
 	service.DisplayName = name
 	service.Type = "service"
-	service.ID = canonicalizeServiceName(name, idFormat)
+	if id != "" {
+		service.ID = canonicalizeServiceName(id, Canonical)
+	} else {
+		service.ID = canonicalizeServiceName(name, idFormat)
+	}
 	return service
 }
 

--- a/plugins/openapi/pkg/openapi/openapi.go
+++ b/plugins/openapi/pkg/openapi/openapi.go
@@ -55,7 +55,7 @@ func New(directory, specURL, idFormat, serviceName string) (*Client, error) {
 			if doc.Info.Extensions == nil {
 				doc.Info.Extensions = make(map[string]interface{}, 0)
 			}
-			doc.Info.Extensions["ServiceName"] = serviceName
+			doc.Info.Extensions["ServiceName"] = canonicalizeServiceName(serviceName, Canonical)
 		}
 		c.docs = append(c.docs, doc)
 	}
@@ -114,27 +114,27 @@ func (c *Client) ListAPIsInService(service *openapi3.T, idFormat string) []API {
 	for pathKey, pathItem := range service.Paths.Map() {
 
 		if pathItem.Get != nil {
-			api := newAPI(serviceID, "GET", pathKey, idFormat)
+			api := newAPI(serviceID, service.Info.Title, "GET", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Post != nil {
-			api := newAPI(serviceID, "POST", pathKey, idFormat)
+			api := newAPI(serviceID, service.Info.Title, "POST", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Put != nil {
-			api := newAPI(serviceID, "PUT", pathKey, idFormat)
+			api := newAPI(serviceID, service.Info.Title, "PUT", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Patch != nil {
-			api := newAPI(serviceID, "PATCH", pathKey, idFormat)
+			api := newAPI(serviceID, service.Info.Title, "PATCH", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Delete != nil {
-			api := newAPI(serviceID, "DELETE", pathKey, idFormat)
+			api := newAPI(serviceID, service.Info.Title, "DELETE", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 		if pathItem.Options != nil {
-			api := newAPI(serviceID, "OPTIONS", pathKey, idFormat)
+			api := newAPI(serviceID, service.Info.Title, "OPTIONS", pathKey, idFormat)
 			apis = append(apis, *api)
 		}
 	}
@@ -146,22 +146,21 @@ func newService(name, id, idFormat string) *Service {
 	service := &Service{}
 	service.DisplayName = name
 	service.Type = "service"
-	if id != "" {
-		service.ID = canonicalizeServiceName(id, Canonical)
-	} else {
+	service.ID = id
+	if id == "" {
 		service.ID = canonicalizeServiceName(name, idFormat)
 	}
 	return service
 }
 
-func newAPI(service, method, path, idFormat string) *API {
+func newAPI(serviceID, serviceName, method, path, idFormat string) *API {
 	api := &API{}
 	api.Type = "endpoint"
-	api.Service = service
+	api.ServiceID = serviceID
+	api.Service = serviceName
 	api.Method = method
 	api.Path = path
 	api.DisplayName = fmt.Sprintf("%s %s", method, path)
-	api.ServiceID = canonicalizeServiceName(api.Service, idFormat)
 	api.ID = canonicalizeEndpoint(api.ServiceID, method, path, idFormat)
 	return api
 }


### PR DESCRIPTION
Add a CLI argument to `ds-load-openapi` to pass in the service name instead of deriving it from the OpenAPI "Title" field.
